### PR TITLE
Add additional support for INLA installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,33 +1,4 @@
-FROM rocker/r-ubuntu as base
-
-RUN apt-get update
-RUN apt-get install -y libudunits2-dev
-RUN apt-get install -y libproj-dev
-RUN apt-get install -y libgdal-dev
-RUN apt-get install -y libgeos-dev
-RUN apt-get install -y pandoc
-
-RUN mkdir /project
-WORKDIR /project
-
-RUN mkdir -p renv
-COPY renv.lock renv.lock
-COPY .Rprofile .Rprofile
-COPY renv/activate.R renv/activate.R
-COPY renv/settings.json renv/settings.json
-
-RUN mkdir renv/.cache
-ENV RENV_PATHS_CACHE renv/.cache
-
-RUN R -e "renv::restore()"
-RUN Rscript -e "install.packages('INLA', repos=c(getOption('repos'), INLA='https://inla.r-inla-download.org/R/testing'), dep=TRUE); renv::snapshot(prompt=FALSE)"
-
-###### DO NOT EDIT STAGE 1 BUILD LINES ABOVE ######
-
-FROM rocker/r-ubuntu
-
-WORKDIR /project
-COPY --from=base /project .
+FROM dbenkeser/inla
 
 COPY Makefile .
 COPY Final_Project_Report.Rmd .

--- a/inla_Dockerfile
+++ b/inla_Dockerfile
@@ -1,0 +1,42 @@
+FROM rocker/r-ubuntu as base
+
+RUN mkdir /project
+WORKDIR /project
+
+# non-interactive mode
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update
+RUN apt-get install -y libudunits2-dev
+RUN apt-get install -y libgdal-dev
+
+# install R libraries needed for analysis
+RUN Rscript -e 'install.packages("sf", repos="https://cran.rstudio.com")'
+RUN Rscript -e 'install.packages("spdep", repos="https://cran.rstudio.com")'
+RUN Rscript -e 'install.packages("rgdal", repos="https://cran.rstudio.com")'
+RUN Rscript -e 'install.packages("maptools", repos="https://cran.rstudio.com")'
+RUN Rscript -e 'install.packages("maps", repos="https://cran.rstudio.com")'
+RUN Rscript -e 'install.packages("readr", repos="https://cran.rstudio.com")'
+RUN Rscript -e 'install.packages("ggthemes", repos="https://cran.rstudio.com")'
+RUN Rscript -e 'install.packages("spatialreg", repos="https://cran.rstudio.com")'
+RUN Rscript -e 'install.packages("tidyverse", repos="https://cran.rstudio.com")'
+RUN Rscript -e 'install.packages("rmarkdown", repos="https://cran.rstudio.com")'
+RUN Rscript -e 'install.packages("labelled", repos="https://cran.rstudio.com")'
+RUN Rscript -e 'install.packages("gtsummary", repos="https://cran.rstudio.com")'
+RUN Rscript -e 'install.packages("ggpubr", repos="https://cran.rstudio.com")'
+
+RUN Rscript -e 'install.packages("INLA", repos=c(getOption("repos"), INLA="https://inla.r-inla-download.org/R/stable"), dep=TRUE)'
+
+RUN Rscript -e 'install.packages("here", repos="https://cran.rstudio.com")'
+
+RUN apt-get update
+RUN apt-get install -y pandoc libfontconfig1-dev libharfbuzz-dev libfribidi-dev
+RUN Rscript -e 'install.packages("tidyverse", repos="https://cran.rstudio.com")'
+
+RUN apt-get install -y cmake
+RUN Rscript -e 'install.packages("ggpubr", repos="https://cran.rstudio.com")'
+
+RUN apt-get install -y pandoc
+
+RUN Rscript -e "tinytex::install_tinytex()"
+ENV PATH="${PATH}:/root/bin"


### PR DESCRIPTION
Installing `INLA` via `renv` is apparently quite difficult. I have no idea what the underlying issue is, but would guess it has to do with the fact that both packages apparently rely on sym links. I suspect they may conflict with one another? No clue.

In any case, this PR adds `inla_Dockerfile` wherein I install `INLA` and other needed packages for your report. I have built that image and [pushed it to my Dockerhub account](https://hub.docker.com/repository/docker/dbenkeser/inla/general).

I have modified `Dockerfile` to pull from that image so that you do not need to rebuild (the build took >1 hour). You should be able to start `FROM dbenkeser/inla` to save yourself some time.

This should get you over the hump in terms of installing `INLA`. I'll leave the rest of the final project requirements for you to figure out. 